### PR TITLE
Update endpoint because of changed URL

### DIFF
--- a/custom_components/coronavirus_hessen/const.py
+++ b/custom_components/coronavirus_hessen/const.py
@@ -1,5 +1,5 @@
 """Constants for the Coronavirus Hessen integration."""
 DOMAIN = "coronavirus_hessen"
-ENDPOINT = "https://soziales.hessen.de/gesundheit/infektionsschutz/coronavirus-sars-cov-2/taegliche-uebersicht-der-bestaetigten-sars-cov-2-faelle-hessen"
+ENDPOINT = "https://soziales.hessen.de/Corona/Bulletin/Tagesaktuelle-Zahlen"
 ATTRIBUTION = "Data provided by Hessisches Ministerium für Soziales und Integration"
 OPTION_TOTAL = "total"


### PR DESCRIPTION
It looks like the Social Ministry updated or relaunched its website (structure), a lot of links don't work anymore.

[This](https://soziales.hessen.de/Corona/Bulletin/Tagesaktuelle-Zahlen) seems to be the new url for the daily updated numbers. Fortunately, the HTML structure does NOT seem to have changed significantly, so the scraping still works as is (on my HA dev setup).